### PR TITLE
Redesign: editorial typography and ink & paper palette

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# Project: jonm.cc (personal blog & portfolio)
+
+Next.js 16 (App Router) + Tailwind 3.4 + TypeScript. Content in MDX. Deployed on Vercel.
+
+## Commands
+
+- `npm run dev` — local dev server
+- `npm run build` — production build (also runs as pre-push hook)
+- `npm run lint:fix` — ESLint
+- `npm run format` — Prettier
+- `npm run test` — Jest unit tests
+- `npm run test:e2e` — Playwright
+
+## Design System
+
+### Typography (three-font system)
+
+- **Fraunces** (`--font-display`) — display/headings. Used for page titles, section headings on CV. Settings: `font-weight: 500`, `font-variation-settings: 'WONK' 0, 'SOFT' 50`.
+- **Nunito Sans** (`--font-body`) — body text. Used for prose content, CV descriptions, blog posts.
+- **Geist Sans / Geist Mono** — UI chrome only: nav, footer links, metadata, code blocks.
+
+### Color Palette (ink & paper)
+
+Warm-shifted neutrals defined as CSS variables in `app/styles/base.css`. Tailwind's `neutral-*` scale is remapped to these in `tailwind.config.js`.
+
+| Token                 | Light                    | Dark                   |
+| --------------------- | ------------------------ | ---------------------- |
+| `--color-surface`     | `#F9F6F1` (cream)        | `#1C1917` (warm black) |
+| `--color-primary`     | `#B85C38` (burnt sienna) | `#D4825E` (lighter)    |
+| `--color-neutral-800` | `#2A2520` (text)         | —                      |
+| `--color-neutral-100` | `#F0EBE3`                | —                      |
+
+Full neutral scale: 100–900, all warm-shifted (brown undertone, not cool gray).
+
+### Key Patterns
+
+- **Link hover**: animated underline via `background-size` transition (prose) or `scaleX` pseudo-element (nav/footer)
+- **Dark mode**: class-based (`darkMode: 'class'`), stored in localStorage, respects system preference
+- **Layout width**: animated container that expands for portfolio pages (narrow: 36rem, wide: 56rem)
+- **Motion**: Framer Motion on CV page (staggered fade-in). Respects `prefers-reduced-motion`.
+- **Selection**: warm sienna tint (`rgba(184, 92, 56, 0.15)`)
+
+## Content
+
+- Blog posts: `content/blog/*.mdx`
+- Portfolio projects: `content/portfolio/*.mdx`
+- CV jobs: `content/cv/*.mdx`
+
+## Conventions
+
+- Pre-commit hook runs Prettier check; pre-push runs full build
+- Use CSS custom properties for colors, not hardcoded hex in components
+- Prefer CSS classes in `base.css` over inline Tailwind for complex/reusable styles

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -20,9 +20,9 @@ type FeedItem = {
 function PostSkeleton() {
   return (
     <div className="animate-pulse mb-8">
-      <div className="h-7 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-2" />
-      <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full mb-1" />
-      <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
+      <div className="h-7 bg-neutral-200 dark:bg-neutral-700 rounded w-3/4 mb-2" />
+      <div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-full mb-1" />
+      <div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-1/2" />
     </div>
   )
 }

--- a/app/components/cv/ExperienceItem.tsx
+++ b/app/components/cv/ExperienceItem.tsx
@@ -25,7 +25,7 @@ export function ExperienceItem({
 }: ExperienceItemProps) {
   return (
     <motion.div className="cv-experience-item">
-      <h3 className="font-semibold text-neutral-900 dark:text-neutral-100 uppercase">{position}</h3>
+      <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">{position}</h3>
       <div className="text-neutral-600 dark:text-neutral-400 mb-1">
         {companyLink ? (
           <a

--- a/app/components/cv/Section.tsx
+++ b/app/components/cv/Section.tsx
@@ -16,7 +16,11 @@ export function Section({ title, children }: SectionProps) {
       viewport={{ once: true }}
       transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
     >
-      <motion.h2 className="font-semibold text-2xl mb-6 tracking-tighter" layout>
+      <motion.h2
+        className="text-2xl mb-6 tracking-tight"
+        style={{ fontFamily: 'var(--font-display), Georgia, serif', fontWeight: 400 }}
+        layout
+      >
         {title}
       </motion.h2>
       {children}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -21,7 +21,7 @@ export default function Footer() {
     <footer className="mt-12 mb-16 flex flex-col items-start">
       <div className="flex flex-col md:flex-row gap-4 md:gap-8 text-sm text-neutral-600 dark:text-neutral-400">
         <a
-          className="footer-link group flex items-center hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 focus-visible:rounded-sm focus:outline-none"
+          className="footer-link group flex items-center hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-primary)] focus-visible:rounded-sm focus:outline-none"
           rel="noopener noreferrer"
           target="_blank"
           href="/rss"
@@ -31,7 +31,7 @@ export default function Footer() {
           <ArrowIcon />
         </a>
         <a
-          className="footer-link group flex items-center hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 focus-visible:rounded-sm focus:outline-none"
+          className="footer-link group flex items-center hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-primary)] focus-visible:rounded-sm focus:outline-none"
           rel="noopener noreferrer"
           target="_blank"
           href="https://github.com/jonmccull/blog/"

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -41,7 +41,7 @@ export function Navbar() {
                     text-neutral-600 dark:text-neutral-400
                     hover:text-neutral-900 dark:hover:text-neutral-100
                     flex align-middle relative py-1 px-0 mr-3
-                    focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 focus-visible:rounded-sm
+                    focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-primary)] focus-visible:rounded-sm
                     ${isActive ? 'nav-link-active text-neutral-900 dark:text-neutral-100' : ''}
                   `}
                 >

--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -49,26 +49,21 @@ export default function CVPage() {
       {/* Header */}
       <FadeIn>
         <header className="mb-12">
-          <h1 className="text-3xl tracking-tighter mb-2">
-            <strong>Jon McCullough</strong> — Product Marketer
-          </h1>
-          <div className="flex gap-3 text-neutral-700 dark:text-neutral-300">
+          <h1 className="home-name mb-3">Jon McCullough</h1>
+          <p className="text-xl text-neutral-500 mb-4">Product Marketer</p>
+          <nav className="flex gap-4" aria-label="Contact links">
             <a
               href="https://www.linkedin.com/in/jonmccullough/"
-              className="link-underline hover:text-neutral-900 dark:hover:text-neutral-100"
+              className="home-link"
               target="_blank"
               rel="noopener noreferrer"
             >
               LinkedIn
             </a>
-            <span>•</span>
-            <a
-              href="mailto:hey@jonm.cc"
-              className="link-underline hover:text-neutral-900 dark:hover:text-neutral-100"
-            >
+            <a href="mailto:hey@jonm.cc" className="home-link">
               Mail
             </a>
-          </div>
+          </nav>
         </header>
       </FadeIn>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -124,10 +124,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
         <JsonLd data={websiteSchema} />
       </head>
-      <body
-        className="antialiased h-full"
-        style={{ backgroundColor: 'var(--color-surface)', color: 'var(--color-neutral-800)' }}
-      >
+      <body className="antialiased h-full">
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-neutral-900 focus:text-white dark:focus:bg-white dark:focus:text-neutral-900 focus:rounded-md focus:outline-none"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './styles/base.css'
 import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
+import { Fraunces, Nunito_Sans } from 'next/font/google'
 import { Navbar } from './components/nav'
 import Footer from './components/footer'
 import { baseUrl } from './sitemap'
@@ -75,13 +76,34 @@ const websiteSchema = {
   },
 }
 
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  variable: '--font-display',
+  display: 'swap',
+})
+
+const nunitoSans = Nunito_Sans({
+  subsets: ['latin'],
+  variable: '--font-body',
+  display: 'swap',
+})
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={cx('h-full', GeistSans.variable, GeistMono.variable)}>
+    <html
+      lang="en"
+      className={cx(
+        'h-full',
+        GeistSans.variable,
+        GeistMono.variable,
+        fraunces.variable,
+        nunitoSans.variable
+      )}
+    >
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5" />
-        <meta name="theme-color" content="#171717" media="(prefers-color-scheme: dark)" />
-        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#1C1917" media="(prefers-color-scheme: dark)" />
+        <meta name="theme-color" content="#F9F6F1" media="(prefers-color-scheme: light)" />
         <script
           dangerouslySetInnerHTML={{
             __html: `
@@ -102,7 +124,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
         <JsonLd data={websiteSchema} />
       </head>
-      <body className="bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 antialiased h-full">
+      <body
+        className="antialiased h-full"
+        style={{ backgroundColor: 'var(--color-surface)', color: 'var(--color-neutral-800)' }}
+      >
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-neutral-900 focus:text-white dark:focus:bg-white dark:focus:text-neutral-900 focus:rounded-md focus:outline-none"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,57 +7,51 @@ export const metadata = {
 
 export default function HomePage() {
   return (
-    <div className="max-w-2xl home-content home-card">
-      <h1 className="text-3xl tracking-tighter mb-8">
-        <span className="font-bold">Jon McCullough</span>{' '}
-        <span className="font-normal text-neutral-500 dark:text-neutral-400">
-          — Product marketer, positioning specialist, and builder.
-        </span>
-      </h1>
-      <p className="prose dark:prose-invert mb-8">
-        I&apos;ve spent twelve years getting really good at the fundamentals&mdash;positioning,
-        messaging, launching products that resonate&mdash;working with{' '}
-        <a href="https://www.slite.com/" target="_blank" rel="noopener noreferrer">
-          B2B startups
-        </a>
-        , leading{' '}
-        <a href="https://www.todoist.com/" target="_blank" rel="noopener noreferrer">
-          consumer apps
-        </a>
-        , and niche{' '}
-        <a href="https://www.vivaldi.com/" target="_blank" rel="noopener noreferrer">
-          web browsers
-        </a>
-        .
-      </p>
-      <p className="prose dark:prose-invert mb-8">
-        In my work I strive for simplicity, making sure what we build connects with real people.
-      </p>
-      <p className="prose dark:prose-invert mb-8">I’m open to new roles. Let’s connect. ✌️</p>
-      <div className="flex gap-3 text-neutral-700 dark:text-neutral-300">
-        <Link
-          href="/cv"
-          className="link-underline hover:text-neutral-900 dark:hover:text-neutral-100"
-        >
+    <div className="home-editorial">
+      <header className="mb-12 md:mb-16">
+        <h1 className="home-name">Jon McCullough</h1>
+        <p className="home-descriptor">Product marketer, positioning specialist, and builder.</p>
+      </header>
+
+      <div className="home-body">
+        <p>
+          I&apos;ve spent twelve years getting really good at the fundamentals&mdash;positioning,
+          messaging, launching products that resonate&mdash;working with{' '}
+          <a href="https://www.slite.com/" target="_blank" rel="noopener noreferrer">
+            B2B startups
+          </a>
+          , leading{' '}
+          <a href="https://www.todoist.com/" target="_blank" rel="noopener noreferrer">
+            consumer apps
+          </a>
+          , and niche{' '}
+          <a href="https://www.vivaldi.com/" target="_blank" rel="noopener noreferrer">
+            web browsers
+          </a>
+          .
+        </p>
+        <p>
+          In my work I strive for simplicity, making sure what we build connects with real people.
+        </p>
+        <p>I&apos;m open to new roles. Let&apos;s connect. &#x270C;&#xFE0F;</p>
+      </div>
+
+      <nav className="home-links" aria-label="Contact links">
+        <Link href="/cv" className="home-link">
           CV
         </Link>
-        <span>•</span>
         <a
           href="https://www.linkedin.com/in/jonmccullough/"
-          className="link-underline hover:text-neutral-900 dark:hover:text-neutral-100"
+          className="home-link"
           target="_blank"
           rel="noopener noreferrer"
         >
           LinkedIn
         </a>
-        <span>•</span>
-        <a
-          href="mailto:hey@jonm.cc"
-          className="link-underline hover:text-neutral-900 dark:hover:text-neutral-100"
-        >
+        <a href="mailto:hey@jonm.cc" className="home-link">
           Mail
         </a>
-      </div>
+      </nav>
     </div>
   )
 }

--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -5,18 +5,19 @@
 /* Base styles */
 @layer base {
   :root {
-    /* Colors */
-    --color-primary: #2cafed;
-    --color-primary-light: rgba(44, 175, 237, 0.1);
-    --color-neutral-100: #f5f5f5;
-    --color-neutral-200: #e5e5e5;
-    --color-neutral-300: #d4d4d4;
-    --color-neutral-400: #a3a3a3;
-    --color-neutral-500: #737373;
-    --color-neutral-600: #525252;
-    --color-neutral-700: #404040;
-    --color-neutral-800: #262626;
-    --color-neutral-900: #171717;
+    /* Colors — ink & paper palette */
+    --color-primary: #b85c38;
+    --color-primary-light: rgba(184, 92, 56, 0.1);
+    --color-surface: #f9f6f1;
+    --color-neutral-100: #f0ebe3;
+    --color-neutral-200: #e2dcd3;
+    --color-neutral-300: #ccc5ba;
+    --color-neutral-400: #a69e93;
+    --color-neutral-500: #8a8178;
+    --color-neutral-600: #6b6359;
+    --color-neutral-700: #4a443d;
+    --color-neutral-800: #2a2520;
+    --color-neutral-900: #1c1917;
 
     /* Syntax highlighting */
     --sh-class: rgba(0, 0, 0, 0.88);
@@ -56,8 +57,10 @@
 
   /* Dark mode overrides */
   .dark {
+    --color-surface: #1c1917;
+    --color-primary: #d4825e;
     --sh-class: #4c97f8;
-    --sh-identifier: white;
+    --sh-identifier: #f0ebe3;
     --sh-keyword: #f47067;
     --sh-string: #0fa295;
   }
@@ -92,7 +95,11 @@
 
 /* Selection styles */
 ::selection {
-  @apply bg-yellow-100 dark:bg-yellow-800;
+  background: rgba(184, 92, 56, 0.15);
+}
+
+.dark ::selection {
+  background: rgba(212, 130, 94, 0.25);
 }
 
 /* Prose styles */
@@ -281,33 +288,115 @@
   opacity: 0.4;
 }
 
-/* Home page card */
-.home-card {
-  border: 1px solid var(--color-neutral-200);
-  border-radius: 1rem;
-  padding: 1.25rem;
+/* Home page — editorial layout */
+.home-editorial {
+  max-width: 32rem;
+  padding-top: 4rem;
 }
 
 @media (min-width: 768px) {
-  .home-card {
-    padding: 2rem;
+  .home-editorial {
+    padding-top: 8rem;
   }
 }
 
-.dark .home-card {
+.home-name {
+  font-family: var(--font-display), Georgia, serif;
+  font-weight: 500;
+  font-variation-settings:
+    'WONK' 0,
+    'SOFT' 50;
+  font-size: 3rem;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--color-neutral-900);
+  margin: 0 0 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .home-name {
+    font-size: 3.75rem;
+  }
+}
+
+.dark .home-name {
+  color: #f0ebe3;
+}
+
+.home-descriptor {
+  font-size: 1.125rem;
+  line-height: 1.5;
+  color: var(--color-neutral-500);
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.home-body {
+  margin-bottom: 3rem;
+}
+
+.home-body p {
+  font-family: var(--font-body), system-ui, sans-serif;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--color-neutral-700);
+  margin: 0 0 1.25rem;
+}
+
+.dark .home-body p {
+  color: #ccc5ba;
+}
+
+.home-body p:last-child {
+  margin-bottom: 0;
+}
+
+.home-body a {
+  color: var(--color-primary);
+  opacity: var(--link-text-opacity);
+  text-decoration: none;
+  background-image: linear-gradient(var(--link-underline-color), var(--link-underline-color));
+  background-position: 50% 100%;
+  background-repeat: no-repeat;
+  background-size: 0% var(--link-underline-width);
+  padding-bottom: 0.1em;
+  transition: all var(--transition-normal) ease-in-out;
+}
+
+.home-body a:hover,
+.home-body a:focus {
+  opacity: 1;
+  background-size: 100% var(--link-underline-width);
+}
+
+.home-links {
+  display: flex;
+  gap: 1.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--color-neutral-200);
+}
+
+.dark .home-links {
   border-color: var(--color-neutral-800);
 }
 
-/* Home page link styles - footer links only */
-.home-content .link-underline {
-  opacity: var(--link-text-opacity);
+.home-link {
+  font-size: 0.875rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-neutral-500);
   text-decoration: none;
-  transition: all var(--transition-normal) ease;
+  transition: color var(--transition-normal) ease;
 }
 
-.home-content .link-underline:hover,
-.home-content .link-underline:focus {
-  opacity: 1;
+.home-link:hover,
+.home-link:focus {
+  color: var(--color-neutral-900);
+}
+
+.dark .home-link:hover,
+.dark .home-link:focus {
+  color: var(--color-neutral-100);
 }
 
 /* Remove prose link underline from all blog feed items */
@@ -338,7 +427,7 @@
   padding: 1rem 1.5rem;
   margin-left: -1.5rem;
   margin-right: -1.5rem;
-  background-color: #f3f0e7;
+  background-color: var(--color-neutral-100);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -346,15 +435,15 @@
 }
 
 .blog-card-featured:hover {
-  background-color: #eae6db;
+  background-color: var(--color-neutral-200);
 }
 
 .dark .blog-card-featured {
-  background-color: #1c1917;
+  background-color: #2a2520;
 }
 
 .dark .blog-card-featured:hover {
-  background-color: #292524;
+  background-color: #332d27;
 }
 
 /* Portfolio wrapper - breaks out of narrow parent container */

--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -77,9 +77,15 @@
 
   body {
     min-height: 100%;
+    background-color: var(--color-surface);
+    color: var(--color-neutral-800);
     transition:
       background-color var(--transition-normal),
       color var(--transition-normal);
+  }
+
+  .dark body {
+    color: var(--color-neutral-100);
   }
 
   /* Disable transitions on initial load to prevent flash */
@@ -100,6 +106,13 @@
 
 .dark ::selection {
   background: rgba(212, 130, 94, 0.25);
+}
+
+/* Body font for prose and CV content */
+.prose,
+.cv-job-description,
+.cv-experience-item p {
+  font-family: var(--font-body), system-ui, sans-serif;
 }
 
 /* Prose styles */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,19 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
+      colors: {
+        neutral: {
+          100: 'var(--color-neutral-100)',
+          200: 'var(--color-neutral-200)',
+          300: 'var(--color-neutral-300)',
+          400: 'var(--color-neutral-400)',
+          500: 'var(--color-neutral-500)',
+          600: 'var(--color-neutral-600)',
+          700: 'var(--color-neutral-700)',
+          800: 'var(--color-neutral-800)',
+          900: 'var(--color-neutral-900)',
+        },
+      },
       typography: {
         DEFAULT: {
           css: {


### PR DESCRIPTION
## Summary
- **Typography**: Add Fraunces (display) + Nunito Sans (body) font pairing, replacing Geist-only setup. Three-font system: Fraunces for headings, Nunito Sans for body, Geist for UI chrome.
- **Color palette**: Replace cold neutral/blue palette with warm "ink & paper" tones — cream surface (#F9F6F1), warm charcoal text, burnt sienna accent (#B85C38). Full warm-shifted neutral scale.
- **Home page**: Editorial layout with large serif name, generous vertical spacing, uppercase letterspaced contact links, no bordered card.
- **CV page**: Same title treatment as home, Fraunces section headings, cleaner type hierarchy.
- **Site-wide**: Tailwind neutral scale remapped to warm CSS variables, body font propagated to all prose content, warm selection highlights, accent-colored focus rings.

## Test plan
- [ ] Verify home page renders correctly in light and dark mode
- [ ] Verify blog index, post pages, and portfolio pages use warm palette
- [ ] Verify CV page typography hierarchy looks correct
- [ ] Check dark mode toggle transitions smoothly
- [ ] Test on mobile viewports
- [ ] Verify accessibility: focus rings visible, reduced motion respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)