### PR TITLE
Bump postcss to 8.5.10+ (fixes Dependabot alert #103)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "geist": "1.4.2",
         "next": "^16.2.6",
         "next-mdx-remote": "^6.0.0",
-        "postcss": "^8.4.38",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "sugar-high": "^0.6.1"
@@ -38,6 +37,7 @@
         "husky": "^9.1.7",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
+        "postcss": "^8.5.14",
         "prettier": "^3.5.3",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.9.3"
@@ -9026,33 +9026,6 @@
         "react": ">=16"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9601,9 +9574,10 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9619,7 +9593,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "geist": "1.4.2",
     "next": "^16.2.6",
     "next-mdx-remote": "^6.0.0",
-    "postcss": "^8.4.38",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "sugar-high": "^0.6.1"
@@ -49,6 +48,7 @@
     "husky": "^9.1.7",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
+    "postcss": "^8.5.14",
     "prettier": "^3.5.3",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.9.3"
@@ -60,6 +60,7 @@
     "flatted": "^3.4.2",
     "yaml": "^2.8.3",
     "picomatch@2": "^2.3.2",
-    "picomatch@4": "^4.0.4"
+    "picomatch@4": "^4.0.4",
+    "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps direct `postcss` devDep to `^8.5.14`.
- Adds `"postcss": "$postcss"` override so the copy bundled deep inside `next@16.2.6/node_modules` (which was still `8.4.31`) dedupes against the same safe install. After install, only `postcss@8.5.14` exists in `node_modules`.

## Alert resolved

[#103](https://github.com/jonmccull/blog/security/dependabot/103) — medium severity, [GHSA-...](https://github.com/advisories): `postcss <8.5.10` has XSS via unescaped `</style>` in CSS Stringify output.

In practice this wasn't exploitable here — postcss only runs at build time on Tailwind + our own CSS, never on untrusted input — but clearing the alert keeps the dashboard clean.

## Test plan

- [x] `npm test` → 65/65 pass
- [x] `npm run build` passes (pre-push hook also runs it)
- [x] `prettier --check` passes (pre-commit hook)
- [ ] Vercel preview build succeeds
- [ ] Confirm alert #103 auto-closes after merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)